### PR TITLE
Fixing Jar name

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Build the project by either executing
   * gradlew (eg if you don't have Gradle installed)
   * or the Gradle build file (build.gradle)
 
-Execute the resulting Jar: java -jar superlog-1.0.jar
+Execute the resulting Jar: java -jar superlog-1.0-standalone.jar
 
 ## MacOS
 Run with JVM option -XstartOnFirstThread (useful to run it from IntelliJ)


### PR DESCRIPTION
Fixing Jar file name, Gradle now generates the Jar: superlog-1.0-standalone.jar